### PR TITLE
Remove double-addition of backflow stabilization at outlet

### DIFF
--- a/demos/heart-valve-moving-mesh/heart-valve-moving-mesh.py
+++ b/demos/heart-valve-moving-mesh/heart-valve-moving-mesh.py
@@ -882,7 +882,7 @@ res_f += vrmt.stableNeumannBC(-Q*FLUID_NUMERICAL["R"]*n,FLUID["rho"],
                                 uhat=uhat_alpha,
                                 vhat=vhat_alpha,
                                 ds=ds(FLAG["fluid_outflow"]),
-                                gamma=FLUID_NUMERICAL["gamma"])
+                                gamma=Constant(0))
 
 ###############################################################
 #### Fluid-Solid Residual #####################################


### PR DESCRIPTION
The plot below shows little difference in changing from gamma = 2.00 at the outlet (current code since the backflow is added twice) to gamma = 1.00 at the outlet (new code).

![OutflowGammaComparison](https://user-images.githubusercontent.com/88906597/204695537-47c5b7f0-f966-45d7-9512-3f703b2df4ce.svg)
